### PR TITLE
fix: optimize terraform

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -18,3 +18,7 @@ apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 usermod -aG docker ubuntu
 # Remove sudo privileges
 deluser ubuntu sudo
+# Make ubuntu owner of socket
+chown ubuntu:docker /var/run/docker.sock
+
+touch /home/setup_finished.txt

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -18,7 +18,5 @@ apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 usermod -aG docker ubuntu
 # Remove sudo privileges
 deluser ubuntu sudo
-# Make ubuntu owner of socket
-chown ubuntu:docker /var/run/docker.sock
 
 touch /home/setup_finished.txt

--- a/deploy/vm.tf
+++ b/deploy/vm.tf
@@ -32,6 +32,7 @@ resource "google_compute_instance" "adsp" {
 
   provisioner "remote-exec" {
     inline = [
+      "until [ -f /home/setup_finished.txt ] && [ -f /home/ubuntu/production.docker-compose.yml ]; do sleep 30; done",
       "docker compose -f /home/ubuntu/production.docker-compose.yml up -d --quiet-pull"
     ]
   }

--- a/deploy/vm.tf
+++ b/deploy/vm.tf
@@ -33,7 +33,9 @@ resource "google_compute_instance" "adsp" {
   provisioner "remote-exec" {
     inline = [
       "until [ -f /home/setup_finished.txt ] && [ -f /home/ubuntu/production.docker-compose.yml ]; do sleep 30; done",
-      "docker compose -f /home/ubuntu/production.docker-compose.yml up -d --quiet-pull"
+      "newgrp docker << EOF",
+      "docker compose -f /home/ubuntu/production.docker-compose.yml up -d --quiet-pull",
+      "EOF"
     ]
   }
 }


### PR DESCRIPTION
The deployment fails if the setup.sh is still running while the remote-exec is executed, which will be checked. As in this case the groups won't be updated we would need to make the ubuntu user owner of the docker socket, as `newgrp docker` can't be executed by the ubuntu user and a reboot would introduce too much overhead.